### PR TITLE
Workaround for the complete budget problem in RESAFT-17

### DIFF
--- a/lib/kuality-coeus/data_objects/budget/budget_versions.rb
+++ b/lib/kuality-coeus/data_objects/budget/budget_versions.rb
@@ -178,35 +178,12 @@ class BudgetVersionsObject < DataFactory
   end
 
   def complete
-    raise 'This method is currently failing because of how the OK button responds to the click'
-    # FIXME: For whatever reason, the clicking of the OK button short-circuits the system
-    # being able to mark the budget complete.
     view 'Periods And Totals'
-
-    while on(PeriodsAndTotals).complete_budget_element.present?
-      on(PeriodsAndTotals).complete_budget
-      on CompleteBudget do |page|
-        page.ready.set
-        page.ok
-      end
-      on(PeriodsAndTotals).loading
-      DEBUG.pause 30
-
-      visit Logout
-      visit Login do |log_in|
-        log_in.username.set $current_user.user_name
-        log_in.login
-      end
-      on(Header).doc_search_link.wait_until_present
-      view 'Periods And Totals'
-
-      DEBUG.message x
-      x += 1
-
+    on(NewDocumentHeader).budget_settings
+    on BudgetSettings do |page|
+      page.status.pick! 'Complete'
+      page.apply_changes
     end
-
-    DEBUG.message
-
   end
 
   def update_from_parent(navigate_method)


### PR DESCRIPTION
Complete budget by going into budget settings instead of using the button on the page.